### PR TITLE
Add backpack example, comment cleanup

### DIFF
--- a/examples/backpack.js
+++ b/examples/backpack.js
@@ -1,5 +1,5 @@
-// This example shows how to use node-pixel using Johnny Five as the
-// hook for the board.
+// This example shows how to use node-pixel using Johnny Five to
+// control the backpack.
 
 var five = require("johnny-five");
 var pixel = require("../lib/pixel.js");
@@ -20,7 +20,7 @@ board.on("ready", function() {
         data: 6,
         length: 17,
         board: this,
-        controller: "FIRMATA"
+        controller: "I2CBACKPACK"
     });
 
     strip.on("ready", function() {

--- a/examples/panel.js
+++ b/examples/panel.js
@@ -1,5 +1,4 @@
-
-// This example shows how to use node-pixel using Johnny Five as the 
+// This example shows how to use node-pixel using Johnny Five as the
 // hook for the board.
 
 var five = require("johnny-five");
@@ -21,8 +20,7 @@ board.on("ready", function() {
         data: 6,
         length: 128,
         board: this,
-        controller: "FIRMATA",
-//        controller: "I2CBACKPACK"
+        controller: "FIRMATA"
     });
 
     strip.on("ready", function() {


### PR DESCRIPTION
I added an example that uses `I2CBACKPACK` as the default controller. This is almost identical to the Johnny-Five example, but I think it's handy to have an example that doesn't require any changes for backpacks.

I also removed some comments from the other examples just to clean things up.