### PR TITLE
Pass opts to i2cConfig

### DIFF
--- a/lib/pixel.js
+++ b/lib/pixel.js
@@ -190,7 +190,11 @@ var Controllers = {
                 var color_order = opts.color_order || COLOR_ORDER.GRB; // default GRB
 
                 var io = opts.firmata || opts.board.io;
-                var i2caddr = opts.address || I2C_DEFAULT;
+
+                if (!opts.address) {
+                    opts.address = I2C_DEFAULT;
+                }
+
                 if (io == undefined) {
                     throw "An IO object is required to I2C controller";
                 }
@@ -241,14 +245,14 @@ var Controllers = {
                         addr: i,
                         io: io,
                         controller: "I2CBACKPACK",
-                        i2c_address: i2caddr,
+                        i2c_address: opts.address,
                     }) );
                 }
 
                 strips.set(this, {
                     pixels: pixels,
                     io: io,
-                    i2c_address: i2caddr,
+                    i2c_address: opts.address,
                 });
 
                 // now send the config message with length and data point.
@@ -261,9 +265,9 @@ var Controllers = {
                     data.push( (strip.length >> 7) & FIRMATA_7BIT_MASK);
                 });
                 // send the I2C config message.
-                io.i2cConfig();
+                io.i2cConfig(opts);
                 process.nextTick(function() {
-                    io.i2cWrite(i2caddr, data);
+                    io.i2cWrite(opts.address, data);
                     process.nextTick(function() {
                         this.emit("ready", null)
                     }.bind(this) );


### PR DESCRIPTION
`i2cConfig` expects the `opts` object to be passed along, most importantly the `address` property. This was throwing an error on Tessel.