### PR TITLE
fix stripcolor

### DIFF
--- a/lib/pixel.js
+++ b/lib/pixel.js
@@ -358,7 +358,7 @@ Strip.prototype.colour = Strip.prototype.color = function(color, opts) {
             // we have an RGB array value
             stripcolor = color;
         } else {
-            stripcolor = ColorString.get(color) || null;
+            stripcolor = ColorString.get(color).value || null;
         }
     }
 
@@ -370,7 +370,7 @@ Strip.prototype.colour = Strip.prototype.color = function(color, opts) {
         }
 
         // set the whole strip color to the appropriate int value
-        this.strip_color(ColorString.colorValue(stripcolor.value));
+        this.strip_color(ColorString.colorValue(stripcolor));
 
     } else {
         console.log("color supplied couldn't be parsed: " + stripcolor);


### PR DESCRIPTION
stripcolor is meant to be an RGB array. `ColorString.get(color).value` returns the right model. `stripcolor.value` would return `undefined` if `stripcolor` is an array.