### PR TITLE
enable Strict mode to run on node 4 and 6

### DIFF
--- a/lib/pixel.js
+++ b/lib/pixel.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Defines a set of WS2812 LED Pixels for use
 
 // TODO:
@@ -667,14 +669,12 @@ Pixel.prototype.colour = Pixel.prototype.color = function(color, opts) {
         // fill out the values for the pixel and then send the message to update
         // it on the strip
 
-        with (pixel.color) {
-            r = pixelcolor.value[0];
-            g = pixelcolor.value[1];
-            b = pixelcolor.value[2];
-            hexcode = ColorString.to.hex(pixelcolor.value);
-            color = ColorString.to.keyword(pixelcolor.value);
-            rgb = pixelcolor.value;
-        }
+        pixel.color.r = pixelcolor.value[0];
+        pixel.color.g = pixelcolor.value[1];
+        pixel.color.b = pixelcolor.value[2];
+        pixel.color.hexcode = ColorString.to.hex(pixelcolor.value);
+        pixel.color.color = ColorString.to.keyword(pixelcolor.value);
+        pixel.color.rgb = pixelcolor.value;
 
         color = ColorString.colorValue(pixelcolor.value);
         if (sendmsg) {


### PR DESCRIPTION
Otherwise we get errors with the use of `let` and `const`. I also had to remove `with` because it doesn't work in strict mode.