### PR TITLE
px is not defined

### DIFF
--- a/lib/pixel.js
+++ b/lib/pixel.js
@@ -473,7 +473,7 @@ Strip.prototype.shift = function(amt, direction, wrap) {
         let tmp_pixels = strip.pixels.splice(start_element, amt);
 
         while (tmp_pixels.length > 0) {
-            px = tmp_pixels.pop();
+            let px = tmp_pixels.pop();
 
             // set the pixel off if not wrapping.
             if (! wrap) {


### PR DESCRIPTION
attempting to run examples/johnnyfive.js resulted in error
adding missing var declaration seems to correct this

⇒  node examples/johnnyfive.js /dev/cu.Repleo-CH341-00001014
1480913836024 Connected /dev/cu.Repleo-CH341-00001014  
1480913841105 Repl Initialized  
>> Board ready, lets add light
Strip ready, let's go
/Users/coderonin/src/node-pixel/lib/pixel.js:476
            px = tmp_pixels.pop();
               ^

ReferenceError: px is not defined
    at Strip.shift (/Users/coderonin/src/node-pixel/lib/pixel.js:476:16)
    at Timeout._onTimeout (/Users/coderonin/src/node-pixel/examples/johnnyfive.js:40:19)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)