### PR TITLE
Replacing strip.stripLength() with strip.length

### DIFF
--- a/examples/johnnyfive-i2c.js
+++ b/examples/johnnyfive-i2c.js
@@ -34,7 +34,7 @@ board.on("ready", function() {
             strip.color("#000"); // blanks it out
 
             for (var i=0; i< current_pos.length; i++) {
-                if (++current_pos[i] >= strip.stripLength()) {
+                if (++current_pos[i] >= strip.length) {
                     current_pos[i] = 0;
                     if (++current_colors[i] >= colors.length) current_colors[i] = 0;
                 }

--- a/examples/multipin.js
+++ b/examples/multipin.js
@@ -33,7 +33,7 @@ board.on("ready", function() {
 
             strip.color("#000"); // blanks it out
             for (var i=0; i< pixel_list.length; i++) {
-                if (++pixel_list[i] >= strip.stripLength()) {
+                if (++pixel_list[i] >= strip.length) {
                     pixel_list[i] = 0;
                     if (++current_colors[i] >= colors.length) current_colors[i] = 0;
                 }

--- a/examples/rainbow-dynamic-multipin.js
+++ b/examples/rainbow-dynamic-multipin.js
@@ -44,7 +44,7 @@ board.on("ready", function() {
                 cwi = 0;
             }
 
-            for(var i = 0; i < strip.stripLength(); i++) {
+            for(var i = 0; i < strip.length; i++) {
                 showColor = colorWheel( ( cwi+i ) & 255 );
                 strip.pixel( i ).color( showColor );
             }

--- a/examples/rainbow-dynamic.js
+++ b/examples/rainbow-dynamic.js
@@ -46,7 +46,7 @@ board.on("ready", function() {
                 cwi = 0;
             }
 
-            for(var i = 0; i < strip.stripLength(); i++) {
+            for(var i = 0; i < strip.length; i++) {
                 showColor = colorWheel( ( cwi+i ) & 255 );
                 strip.pixel( i ).color( showColor );
             }

--- a/examples/rainbow-static.js
+++ b/examples/rainbow-static.js
@@ -35,8 +35,8 @@ board.on("ready", function() {
         console.log('staticRainbow');
 
         var showColor;
-        for(var i = 0; i < strip.stripLength(); i++) {
-            showColor = colorWheel( ( (i+10)*256 / strip.stripLength() ) & 255 );
+        for(var i = 0; i < strip.length; i++) {
+            showColor = colorWheel( ( (i+10)*256 / strip.length ) & 255 );
             strip.pixel(i).color( showColor);
         }
         strip.show();


### PR DESCRIPTION
stripLength() produces a deprecation warning