### PR TITLE
option to skip firmware check

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ writing in sequence or parallel as appropriate.
 | board | IO Object | IO Board object to use with Johnny Five | undefined | yes(1) |
 | firmata | Firmata board | Firmata board object to use with Firmata directly | undefined | yes(1) |
 | controller | String | I2CBACKPACK, FIRMATA | FIRMATA | no |
+| skip_firmware_check | Boolean | If the controller is FIRMATA, optionally skip the check for the matching node-pixel sketch | false | no |
 | gamma | Number | A number representing the gamma correction for a strip. Can be any decimal number. 2.8 generally works well. | 1.0 (7) | no |
 
 (1) A board or firmata object is required but only one of these needs to be set.

--- a/lib/pixel.js
+++ b/lib/pixel.js
@@ -64,6 +64,7 @@ var Controllers = {
                 var data_pin = opts.data || PIN_DEFAULT;
                 var color_order = opts.color_order || COLOR_ORDER.GRB; // default GRB
                 var strip_definition = opts.strips || new Array();
+                var skip_firmware_check = !!opts.skip_firmware_check;
                 // do firmata / IO checks
                 var firmata = opts.firmata || undefined;
                 if (firmata == undefined) {
@@ -83,7 +84,7 @@ var Controllers = {
                     throw err;
                 }
 
-                if (firmata.firmware.name !== 'node_pixel_firmata.ino') {
+                if (firmata.firmware.name !== 'node_pixel_firmata.ino' && !skip_firmware_check) {
                     let err = new Error("Please upload NodePixel Firmata to the board");
                     err.name = "IncorrectFirmataVersionError";
                     throw err;


### PR DESCRIPTION
I've got a few use cases where I'd like to uses node-pixel/firmata outside of the node_pixel_firmata.ino sketch. 

I'd like to be able to optionally skip the firmware check.