### PR TITLE
transport is the generic name for serialport implementation in firmata

### DIFF
--- a/lib/pixel.js
+++ b/lib/pixel.js
@@ -91,7 +91,7 @@ var Controllers = {
                 }
 
                 // figure out where we are writing to
-                var port = firmata.sp || firmata;
+                var port = firmata.transport || firmata.sp || firmata;
 
                 if (port.write === undefined) {
                     let err = new Error("Node Pixel FIRMATA controller requires IO that can write out");


### PR DESCRIPTION
firmata.js was refactored to allow for different transports to be used. 