### PR TITLE
chore(ci): Changed travis node supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
   - "12"
+  - "14"
 git:
   submodules: false
 


### PR DESCRIPTION
Updated node versions to 12 and 14 for current support for travis