### PR TITLE
fix(gamma): stop color reference leak

### DIFF
--- a/lib/pixel.js
+++ b/lib/pixel.js
@@ -23,11 +23,12 @@ ColorString.colorValue = function colorValue(colors, g_table) {
   // correction table to correct the received value.
 
   // before sending, account for gamma correction.
-  colors[0] = g_table[colors[0]];
-  colors[1] = g_table[colors[1]];
-  colors[2] = g_table[colors[2]];
+  const leakProofColor = Object.assign({}, colors);
+  leakProofColor[0] = g_table[leakProofColor[0]];
+  leakProofColor[1] = g_table[leakProofColor[1]];
+  leakProofColor[2] = g_table[leakProofColor[2]];
 
-  return ((colors[0] << 16) + (colors[1] << 8) + (colors[2]));
+  return ((leakProofColor[0] << 16) + (leakProofColor[1] << 8) + (leakProofColor[2]));
 }
 
 // CONSTANTS


### PR DESCRIPTION
## What does this do?

This is here for this use case:

```js
const five = require("johnny-five");
const pixel = require("node-pixel");
const colorstring = require('color-string');

const getBoard = () => new Promise((res, rej) => {
  const board = new five.Board();
  board.on("ready", () => res(board))
})

const getPixels = (pixOpts) => new Promise((res) => {
  const strip = new pixel.Strip(pixOpts)
  strip.on("ready", () => res(strip));
})
const init = async () => {
  const board = await getBoard();
  const pixels = await getPixels({
    board,
    controller: "FIRMATA",
    strips: [
      {pin: 6, length: 100}
    ],
    gamma: 2.8,
  });
  board.repl.inject({
    strip: pixels
  });
  pixels.color(colorstring.get.rgb('darkorchid'));
  pixels.show();
}
```

When `ColorString.colorValue` is called it modifies the passed in color object directly. That means that each pixel gets shifted, so at the third one its set to `[0, 0, 0]` and due to be a reference they _all_ become black. 

## How can it be fixed without this change?

If you set gamma to `1` the gamma table is a 1 to 1 map to normal colors and has no effect at all. This fixes the issue, but the colors are washed out on my WS2811 pixels.

fixes issue #113 