### PR TITLE
docs: update all docs to reflect new breakdown

### DIFF
--- a/docs/johnnyfive-i2c.md
+++ b/docs/johnnyfive-i2c.md
@@ -24,7 +24,7 @@ start with pin 0 and work upwards from there to 8 max.
 
 ```js
 var five = require("johnny-five");
-var pixel = require("node-pixel.js");
+var pixel = require("node-pixel");
 
 var opts = {};
 opts.port = process.argv[2] || "";

--- a/docs/johnnyfive.md
+++ b/docs/johnnyfive.md
@@ -14,7 +14,7 @@ Wire the neopixel strip up as shown below.
 
 ```js
 var five = require("johnny-five");
-var pixel = require("../lib/pixel.js");
+var pixel = require("node-pixel");
 
 var opts = {};
 opts.port = process.argv[2] || "";

--- a/docs/multipin-i2c.md
+++ b/docs/multipin-i2c.md
@@ -27,7 +27,7 @@ start with pin 0 and work upwards from there to 8 max.
 
 ```js
 var five = require("johnny-five");
-var pixel = require("node-pixel.js");
+var pixel = require("node-pixel");
 
 var opts = {};
 opts.port = process.argv[2] || "";

--- a/examples/channel_fade.js
+++ b/examples/channel_fade.js
@@ -5,7 +5,7 @@
 // hook for the board.
 
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/firmata.js
+++ b/examples/firmata.js
@@ -2,7 +2,7 @@
 // hook for the board.
 
 const firmata = require('firmata');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 if (process.argv[2] == undefined) {

--- a/examples/johnnyfive-i2c.js
+++ b/examples/johnnyfive-i2c.js
@@ -1,7 +1,7 @@
 // This example shows how to use node-pixel using Johnny Five as the
 // hook for the board.
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/johnnyfive.js
+++ b/examples/johnnyfive.js
@@ -1,7 +1,7 @@
 // This example shows how to use node-pixel using Johnny Five as the
 // hook for the board.
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/mega-multipin.js
+++ b/examples/mega-multipin.js
@@ -2,7 +2,7 @@
 // to control multiple strips on the same board
 
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/multipin-i2c.js
+++ b/examples/multipin-i2c.js
@@ -2,7 +2,7 @@
 // to control multiple strips on the same board
 
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/multipin.js
+++ b/examples/multipin.js
@@ -2,7 +2,7 @@
 // to control multiple strips on the same board
 
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/panel.js
+++ b/examples/panel.js
@@ -3,7 +3,7 @@
 // hook for the board.
 
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/rainbow-dynamic-multipin.js
+++ b/examples/rainbow-dynamic-multipin.js
@@ -5,7 +5,7 @@
  * adapted from the examples by @pierceray
  */
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/rainbow-dynamic.js
+++ b/examples/rainbow-dynamic.js
@@ -6,7 +6,7 @@
  * created by @pierceray in June 2015
  */
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/rainbow-static.js
+++ b/examples/rainbow-static.js
@@ -5,7 +5,7 @@
  * created by @pierceray in June 2015
  */
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/repl.js
+++ b/examples/repl.js
@@ -1,7 +1,7 @@
 // This example shows how to use node-pixel using Johnny Five as the
 // hook for the board.
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';

--- a/examples/shift.js
+++ b/examples/shift.js
@@ -1,7 +1,7 @@
 // This example shows how to use node-pixel using Johnny Five as the
 // hook for the board.
 const five = require('johnny-five');
-const pixel = require('../lib/pixel.js');
+const pixel = require('node-pixel');
 
 const opts = {};
 opts.port = process.argv[2] || '';


### PR DESCRIPTION
this fixes up all doc examples so we can merge and deploy the gamma object ref fix. all examples now use the npm package name so that they can be copied verbatim into any project running this library. i also fixed all of the markdown files as well.