### PR TITLE
Makefile build-firmware fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,12 +96,13 @@ test-ci:
 
 # make the Firmata build process to copy the files to the right place
 FIRMATA_DEST_DIR = $(BUILD_DIR)/node_pixel_firmata
-FIRMATA_FILES = $(LIBS_DIR)/firmata/arduino/*.{h,cpp}
+FIRMATA_DIR = $(LIBS_DIR)/firmata/arduino
 
 build-firmata: clean-build-firmata
 	@echo "Creating firmata build files"
 	mkdir $(FIRMATA_DEST_DIR)
-	cp $(FIRMATA_FILES) $(FIRMATA_DEST_DIR)/
+	cp $(FIRMATA_DIR)/*.h $(FIRMATA_DEST_DIR)/
+	cp $(FIRMATA_DIR)/*.cpp $(FIRMATA_DEST_DIR)/
 	cp $(LIBS_DIR)/ws2812/* $(FIRMATA_DEST_DIR)/
 	cp $(LIBS_DIR)/lightws2812/* $(FIRMATA_DEST_DIR)/
 	cp $(SRC_DIR)/controller_src/firmata/* $(FIRMATA_DEST_DIR)/


### PR DESCRIPTION
Fixes: #246 

The `*.{cpp,h}` syntax didn't seem supported by the shell that executes the Makefile on Ubuntu 18.04 (sh, not bash or zsh). So I replaced it for 2 simpler steps. 