### PR TITLE
Update package.json to support firmata

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "color-string": "^1.5.3"
   },
   "peerDependencies": {
-    "firmata": "^0.19.1",
+    "firmata": "^2.0.0",
     "johnny-five": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, there are bugs compiling Node_gyp under MacBook with this old firmata version.